### PR TITLE
Issue #56 beautify build menu

### DIFF
--- a/src/components/MySider/MySetting.vue
+++ b/src/components/MySider/MySetting.vue
@@ -14,15 +14,53 @@
         <label style="color:white">{{file}}</label>
       </Checkbox>
     </template>
-    <button @click="compileAndRun" v-if="pythonMark==false">
-      <p>编译并运行</p>
-    </button>
-    <button @click="compile" v-if="pythonMark==false">
-      <p>编译</p>
-    </button>
-    <button @click="run">
-      <p>运行</p>
-    </button>
+
+    <Row
+      type="flex"
+      justify="center"
+      align="middle"
+      style="margin-top: 10px;"
+      v-if="pythonMark==false"
+    >
+      <Col :span="24" style="text-align:center">
+        <Button
+          type="primary"
+          style="border-radius: 0.4vh; margin: 0 auto; width:200px"
+          @click="compileAndRun"
+        >编译并运行</Button>
+      </Col>
+    </Row>
+
+    <Row
+      type="flex"
+      justify="center"
+      align="middle"
+      style="margin-top: 10px;"
+      v-if="pythonMark==false"
+    >
+      <Col :span="24" style="text-align:center">
+        <Button
+          type="primary"
+          style="border-radius: 0.4vh; margin: 0 auto; width:200px"
+          @click="compile"
+        >编译</Button>
+      </Col>
+    </Row>
+
+    <Row 
+    type="flex" 
+    justify="center" 
+    align="middle" 
+    style="margin-top: 10px;"
+    >
+      <Col :span="24" style="text-align:center">
+        <Button
+          type="primary"
+          style="border-radius: 0.4vh; margin: 0 auto; width:200px"
+          @click="run"
+        >运行</Button>
+      </Col>
+    </Row>
   </Layout>
 </template>
 <script>

--- a/src/components/MySider/MySetting.vue
+++ b/src/components/MySider/MySetting.vue
@@ -1,5 +1,5 @@
 <template>
-  <Layout style="background-color: #808695">
+  <Layout style="background-color: #808695;width:250px;">
     <Row>
       <Col span="24">
         <Card style="border-radius: 0vh">

--- a/src/components/MySider/MySetting.vue
+++ b/src/components/MySider/MySetting.vue
@@ -10,8 +10,18 @@
     </Row>
 
     <template v-for="file in Files">
-      <Checkbox :id="file" :key="file" @on-change="changeState(file)" :value="Show[file]">
-        <label style="color:white">{{file}}</label>
+      <Checkbox
+        :id="file"
+        :key="file"
+        @on-change="changeState(file)"
+        :value="Show[file]"
+        style="margin-left:10%;"
+      >
+        <label
+          style="color:white;line-height:30px;font-family: Consolas;"
+        >{{file.split('/').reverse()[0]}}</label>
+
+        <div style="font-size:12px;font-family: Consolas;" :title="file">{{file | ellipsis}}</div>
       </Checkbox>
     </template>
 
@@ -47,12 +57,7 @@
       </Col>
     </Row>
 
-    <Row 
-    type="flex" 
-    justify="center" 
-    align="middle" 
-    style="margin-top: 10px;"
-    >
+    <Row type="flex" justify="center" align="middle" style="margin-top: 10px;">
       <Col :span="24" style="text-align:center">
         <Button
           type="primary"
@@ -88,6 +93,15 @@ export default {
       Show: {},
       pythonMark: false
     };
+  },
+  filters: {
+    ellipsis(value) {
+      if (!value) return "";
+      if (value.length > 27) {
+        return value.slice(0, 27) + "...";
+      }
+      return value;
+    }
   },
   methods: {
     changeState(data) {


### PR DESCRIPTION
美化构建菜单栏：
1.统一按钮样式，与上传与下载界面的按钮风格相同
2.修改文件选择部分展示样式，将文件路径与文件名分两行显示（模仿vscode编辑区）
3.修复构建菜单栏折叠时内部元素排版变形问题