### PR TITLE
fix: 未打开文件时对其进行debug调试会出错 #117

### DIFF
--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -485,13 +485,17 @@ export default {
         }
       }),
       bridge.$on("readyForDebug", filepath => {
-        let breaklines = getBreakpointLines(this.editorMap[filepath]);
-        for (let i = 0; i < breaklines.length; i++) {
+        if (this.editorMap[filepath]) {
+          let breaklines = getBreakpointLines(this.editorMap[filepath]);
+          for (let i = 0; i < breaklines.length; i++) {
           //let command = "b " + filepath + " " + breaklines[i];
-          let command = "b " + breaklines[i];
-          terminal.runcommand(command);
+            let command = "b " + breaklines[i];
+            terminal.runcommand(command);
+          } 
+          terminal.runcommand("okCanDebug");         
+        } else {
+          terminal.runcommand("okCanDebug");
         }
-        terminal.runcommand("okCanDebug");
         if (this.debuggermark == true) {
           this.changeDebugger();
         }


### PR DESCRIPTION
bug原因：根据文件名获取断点时未判断是否为该文件创建editor
修复：增加判断，如果这个文件没有对应editor（没被打开过），就不获取断点直接开始调试